### PR TITLE
Don't throw Exception if no last name

### DIFF
--- a/simplepyged/records.py
+++ b/simplepyged/records.py
@@ -258,7 +258,7 @@ class Individual(Record):
                 if e.value() != "":
                     name = string.split(e.value(),'/')
                     first = string.strip(name[0])
-                    last = string.strip(name[1])
+                    last = string.strip(name[1]) if len(name) > 1 else None
                 else:
                     for c in e.children_lines():
                         if c.tag() == "GIVN":


### PR DESCRIPTION
Quite a few of my datasets have occurrences where individuals don't have last names. Attempting to get their name results in:

```
Traceback (most recent call last):
  File "<stdin>", line 2, in <module>
  File "simplepyged/records.py", line 261, in name
    last = string.strip(name[1])
IndexError: list index out of range
```

This pull-request change would result in:

```
>>> my_individual.name()  # person with no last name
('Barack Hussein', None)
```
